### PR TITLE
Optional dependencies

### DIFF
--- a/mdbackup/__main__.py
+++ b/mdbackup/__main__.py
@@ -41,8 +41,7 @@ def main():
         print('Check the paths and run again the utility')
         sys.exit(1)
     except KeyError as e:
-        print('Configuration is malformed')
-        print(e.args[0])
+        print(f'Configuration is malformed: key {e.args[0]} is not defined')
         sys.exit(2)
     except JSONDecodeError as e:
         print('Configuration is malformed')
@@ -54,8 +53,13 @@ def main():
     logger = logging.getLogger('mdbackups')
 
     # Prepare secret backends (if any) and its env getters (aka functions that gets the right value from the backend)
-    secret_backends = [(get_secret_backend_implementation(secret.type, secret.config), secret)
-                       for secret in config.secrets]
+    try:
+        secret_backends = [(get_secret_backend_implementation(secret.type, secret.config), secret)
+                           for secret in config.secrets]
+    except ImportError as e:
+        # Log not-found module and exit
+        logger.exception(e.args[0], e.args[1])
+        sys.exit(4)
     secret_env = {}
     for secret_backend, secret in secret_backends:
         for key, secret_key in secret.env.items():

--- a/mdbackup/archive.py
+++ b/mdbackup/archive.py
@@ -40,7 +40,6 @@ def archive_folder(backup_path: Path, folder: Path, strategies: List[StrategyCal
     logger = logging.getLogger(__name__)
     filename = folder.parts[-1] + '.tar'
     directory = folder.relative_to(backup_path)
-    logger.info(f'Compressing directory {folder} into {filename}')
 
     if len(strategies) == 0:
         end_cmd = f' > "{filename}"'
@@ -50,6 +49,7 @@ def archive_folder(backup_path: Path, folder: Path, strategies: List[StrategyCal
             filename += ext
             end_cmd = f'| {cmd}'
 
+    logger.info(f'Compressing directory {folder} into {filename}')
     # Do the compression
     logger.debug(f'Executing command ["bash", "-c", \'tar -c "{str(directory)}" {end_cmd} > "{filename}"\']')
     _exec = subprocess.run(['bash', '-c', f'tar -c "{str(directory)}" {end_cmd} > "{filename}"'],

--- a/mdbackup/check_packages/__init__.py
+++ b/mdbackup/check_packages/__init__.py
@@ -1,0 +1,47 @@
+import functools
+
+
+def check_b2blaze(package: str):
+    try:
+        import b2blaze
+    except ImportError as e:
+        raise ImportError(f'To use {package}, install b2blaze package: pip install b2blaze', e)
+
+
+def check_boto3(package: str):
+    try:
+        import boto3
+    except ImportError as e:
+        raise ImportError(f'To use {package}, you must install boto3: pip install boto3', e)
+
+
+def check_magic(package: str):
+    try:
+        import magic
+    except ImportError as e:
+        raise ImportError(f'To use {package}, you must install python-magic: pip install python-magic', e)
+
+
+def check_requests(package: str):
+    try:
+        import requests
+    except ImportError as e:
+        raise ImportError(f'To use {package}, you must install requests: pip install requests', e)
+
+
+def check_pydrive(package: str):
+    try:
+        from pydrive.auth import GoogleAuth
+        from pydrive.drive import GoogleDrive, GoogleDriveFile
+    except ImportError as e:
+        raise ImportError(f'To use {package}, you must install PyDrive: pip install PyDrive', e)
+
+
+def check(package: str, *funcs):
+    def check_dec(func):
+        @functools.wraps(func)
+        def check_dec_impl(*args, **kwargs):
+            [_func(package) for _func in funcs]
+            return func(*args, **kwargs)
+        return check_dec_impl
+    return check_dec

--- a/mdbackup/config.py
+++ b/mdbackup/config.py
@@ -77,7 +77,7 @@ class SecretConfig(object):
 
 class Config(object):
     """
-    The configuration object. Retreives any configuration of the system from many different places.
+    The configuration object. Retrieves any configuration of the system from many different places.
 
     The main configuration lies on a ``config.json`` file, but parts of the configuration, like environment variables
     or credentials, can be stored in different places, for security reasons.

--- a/mdbackup/secrets/__init__.py
+++ b/mdbackup/secrets/__init__.py
@@ -1,12 +1,26 @@
 from typing import Dict
 
-from mdbackup.secrets.file_backend import FileSecretsBackend
+from mdbackup.check_packages import check, check_requests
 from mdbackup.secrets.secrets import AbstractSecretsBackend
-from mdbackup.secrets.vault_backend import VaultSecretsBackend
+
+
+@check('file secrets backend')
+def load_file_secrets_backend():
+    from mdbackup.secrets.file_backend import FileSecretsBackend
+    return FileSecretsBackend
+
+
+@check('Vault secrets backend', check_requests)
+def load_vault_secrets_backend():
+    from mdbackup.secrets.vault_backend import VaultSecretsBackend
+    return VaultSecretsBackend
 
 
 def get_secret_backend_implementation(name: str, config: Dict[str, any]) -> AbstractSecretsBackend:
-    return {
-        'file': FileSecretsBackend,
-        'vault': VaultSecretsBackend,
-    }[name](config)
+    try:
+        return {
+            'file': load_file_secrets_backend,
+            'vault': load_vault_secrets_backend,
+        }[name]()(config)
+    except KeyError as e:
+        raise KeyError(f'Could not found secret backend {e.args[0]}', e)

--- a/mdbackup/secrets/file_backend.py
+++ b/mdbackup/secrets/file_backend.py
@@ -19,6 +19,16 @@ import json
 from pathlib import Path
 from typing import Dict
 
+try:
+    import yaml
+    try:
+        from yaml import CLoader as Loader
+    except ImportError:
+        from yaml import Loader
+except ImportError:
+    yaml = None
+    Loader = None
+
 from mdbackup.secrets.secrets import AbstractSecretsBackend
 
 
@@ -41,4 +51,8 @@ class FileSecretsBackend(AbstractSecretsBackend):
 
     def get_provider(self, key: str) -> Dict[str, any]:
         contents = self.get_secret(key)
+        if key.endswith('.yaml') or key.endswith('.yml'):
+            if yaml is None:
+                raise ImportError('In order to use yaml files, install pyyaml package: pip install pyyaml')
+            return yaml.load(contents, Loader=Loader)
         return json.loads(contents)

--- a/mdbackup/secrets/vault_backend.py
+++ b/mdbackup/secrets/vault_backend.py
@@ -48,7 +48,7 @@ class VaultSecretsBackend(AbstractSecretsBackend):
     def get_secret(self, key: str) -> str:
         split = key.split('#')
         if len(split) != 2:
-            raise KeyError(f'"{key}" is invalid: expected "backend/path/to/secret#key"')
+            split += 'value'
         return self.__kv_get(split[0])['data'][split[1]]
 
     def get_provider(self, key: str) -> Dict[str, any]:

--- a/mdbackup/storage/__init__.py
+++ b/mdbackup/storage/__init__.py
@@ -1,21 +1,33 @@
-from enum import Enum
 from typing import Optional
 
-from mdbackup.storage.backblaze import B2Storage
-from mdbackup.storage.drive import GDriveStorage
-from mdbackup.storage.s3 import S3Storage
+from mdbackup.check_packages import check, check_b2blaze, check_boto3, check_magic, check_pydrive
 from mdbackup.storage.storage import AbstractStorage, T
 
 
-class StorageImplementation(Enum):
-    GDrive = GDriveStorage
-    S3 = S3Storage
-    B2 = B2Storage
+@check('BackBlaze cloud storage', check_b2blaze, check_magic)
+def load_backblaze_storage():
+    from mdbackup.storage.backblaze import B2Storage
+    return B2Storage
+
+
+@check('Google Drive cloud storage', check_pydrive, check_magic)
+def load_gdrive_storage():
+    from mdbackup.storage.drive import GDriveStorage
+    return GDriveStorage
+
+
+@check('any S3 cloud storage', check_boto3, check_magic)
+def load_s3_storage():
+    from mdbackup.storage.s3 import S3Storage
+    return S3Storage
 
 
 def create_storage_instance(params) -> Optional[AbstractStorage[T]]:
     try:
-        impl = next((impl.value for impl in StorageImplementation if impl.name.lower() == params.type.lower()))
-        return impl(params)
-    except StopIteration:
+        return {
+            'gdrive': load_gdrive_storage,
+            's3': load_s3_storage,
+            'b2': load_backblaze_storage,
+        }[params.type.lower()]()(params)
+    except KeyError:
         return None

--- a/mdbackup/storage/backblaze.py
+++ b/mdbackup/storage/backblaze.py
@@ -21,6 +21,7 @@ from typing import Union, List
 
 from b2blaze import B2
 from b2blaze.models.bucket import B2Bucket
+import magic
 
 from mdbackup.storage.storage import AbstractStorage
 
@@ -60,5 +61,6 @@ class B2Storage(AbstractStorage[str]):
         self.__log.info(f'Uploading file {key} (from {path})')
         with open(str(path.absolute()), 'rb') as file_to_upload:
             ret = self.__bucket.files.upload(contents=file_to_upload,
-                                             file_name=key)
+                                             file_name=key,
+                                             mime_content_type=magic.from_file(str(path.absolute()), mime=True))
         self.__log.debug(ret)

--- a/mdbackup/storage/drive.py
+++ b/mdbackup/storage/drive.py
@@ -171,7 +171,7 @@ class GDriveStorage(AbstractStorage[GoogleDriveFile]):
         file1.SetContentFile(file_path)
         file1.Upload()
 
-    def upload(self, path, parent = None):
+    def upload(self, path, parent=None):
         """
         Uploads something to Google Drive.
         """

--- a/mdbackup/storage/s3.py
+++ b/mdbackup/storage/s3.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Union, List
 
 import boto3
+import magic
 
 from mdbackup.storage.storage import AbstractStorage
 
@@ -66,5 +67,10 @@ class S3Storage(AbstractStorage[str]):
         if key.startswith('/'):
             key = key[1:]
         self.__log.info(f'Uploading file {key} (from {path})')
-        ret = self.__s3.upload_file(str(path.absolute()), self.__bucket, key)
+        ret = self.__s3.upload_file(str(path.absolute()),
+                                    self.__bucket,
+                                    key,
+                                    ExtraArgs={
+                                        'ContentType': magic.from_file(str(path.absolute()), mime=True),
+                                    })
         self.__log.debug(ret)

--- a/mdbackup/utils.sh
+++ b/mdbackup/utils.sh
@@ -148,7 +148,7 @@ function backup-folder() {
     fi
 
     SRC="$1"
-    DST_PARTIAL="./.$2.partial"
+    DST_PARTIAL="./.$(echo $2 | tr '/' '_').partial"
     DST="$2"
     shift
     shift

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,4 @@ setuptools.setup(
         ]
     },
     include_package_data=True,
-    install_requires=[
-        'PyDrive',
-        'python-magic',
-        'requests',
-        'boto3',
-        'b2blaze'
-    ]
 )


### PR DESCRIPTION
 - With this change, all non-basic dependencies (those used in cloud storage providers and secrets backends) are removed from the package and must be installed manually. This way, we reduce the packages installed, which most will be unnecesary.
 - It will check for not-installed packages and throw an error message to the user to install the dependencies.
 - Also added yaml support for file secrets backend (providers).
 - Added mime type when uploading files to S3 and BackBlaze (the latter is bugged in the package and it does not work).
 - Change one log to show after some processing is done (archive).
 - Added support to use subdirectories in `backup-folder` bash function.
 - More documenation :)