### PR TITLE
Added support to run parts of the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,28 @@ You can define as many steps as you wish. The idea is to keep every step as simp
   - **Example**: `backup-file-encrypted /etc/ssh/sshd sys-config/etc/ssh`
 
 
+## Arguments
+
+The tool has a few arguments, in general you won't use them, but to test some parts, could be really useful.
+
+```
+usage: mdbackup [-h] [-c CONFIG] [--backup-only] [--upload-current-only]
+                [--cleanup-only]
+
+Small but customizable utility to create backups and store them in cloud
+storage providers
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        Path to configuration (default: config/config.json)
+  --backup-only         Only does the backup actions
+  --upload-current-only
+                        Only uploads the last backup
+  --cleanup-only        Only does the backup cleanup
+```
+
+
 ## Automating running of backups
 
 In this section, systemd and cron ways are going to be explained. systemd is the preferred way in case your system has it.

--- a/mdbackup/backup.py
+++ b/mdbackup/backup.py
@@ -30,7 +30,7 @@ def generate_backup_path(backups_folder: Path) -> Path:
     Creates a path with the folder (named with the right structure)
     that will be used as backup folder in this run.
     """
-    now = datetime.now()
+    now = datetime.utcnow()
     isostring = now.isoformat(timespec='minutes')
     return Path(backups_folder, isostring)
 


### PR DESCRIPTION
```
$ python -m mdbackup --help
usage: __main__.py [-h] [-c CONFIG] [--backup-only] [--upload-current-only]
                   [--cleanup-only]

Small but customizable utility to create backups and store them in cloud
storage providers

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        Path to configuration (default: config/config.json)
  --backup-only         Only does the backup actions
  --upload-current-only
                        Only uploads the last backup
  --cleanup-only        Only does the backup cleanup
```

main code was moved to a function, but no modification was done in the original code.