### PR TITLE
FTP FTPS SFTP providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This allows you to auto-complete with the elements available in the configuratio
           "compress": "(optional) if true, then the connection is compressed (false by default)",
           "knownHostsPolicy": "(optional) Changes the Known Hosts Policy. 'reject' will reject any connection to a server that is not known (default behaviour), 'auto-add' will add to the known-hosts list this server, 'ignore' will print a warning but it will let you connect.",
           "hostKeysFilePath": "(optional) Path to the known-hosts file",
-          "disableHostKeys": (optional) If set to false, it won't load any known-hosts file (by default is true)"
+          "disableHostKeys": "(optional) If set to false, it won't load any known-hosts file (by default is true)"
         }
     ],
     "hooks": {

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Now you can run the utility (only if you have enabled the virtual env) with `mdb
  >  4. `PyDrive` for Google Drive cloud storage provider
  >  5. `requests` for Vault secrets backend
  >  6. `pyyaml` (optional) for File secrets backend
+ >  7. `paramiko` for the SFTP storage provider 
 
 ## Creating the configuration
 
@@ -159,6 +160,21 @@ This allows you to auto-complete with the elements available in the configuratio
           "acct":  "(optional) Account information for the user",
           "keyFile": "(optional) If needed, define a custom key file",
           "certFile": "(optional) If needed, define a custom certificate file"
+        },
+        {
+          "type": "sftp",
+          "backupsPath": "Path in the SFTP where the backups will be located",
+          "host": "Host where the SFTP server is located",
+          "port": "(optional) Port of the SFTP server (by default 22)",
+          "user": "User to connect to the SFTP server",
+          "password": "(optional) Password for the user",
+          "privateKey": "(optional) Private Key in base64",
+          "privateKeyPath": "(optional) Private Key file path",
+          "allowAgent": "(optional) if true, then the connection will interact with the SSH Agent, false if this behaviour is not desired (false by default)",
+          "compress": "(optional) if true, then the connection is compressed (false by default)",
+          "knownHostsPolicy": "(optional) Changes the Known Hosts Policy. 'reject' will reject any connection to a server that is not known (default behaviour), 'auto-add' will add to the known-hosts list this server, 'ignore' will print a warning but it will let you connect.",
+          "hostKeysFilePath": "(optional) Path to the known-hosts file",
+          "disableHostKeys": (optional) If set to false, it won't load any known-hosts file (by default is true)"
         }
     ],
     "hooks": {
@@ -219,6 +235,29 @@ The content type of the files will be guessed and set in the metadata when uploa
 This provider uses FTP or FTPS to upload the files to a server. Requires the host to be able to connect. It is recommended to use an user and password for security reasons. Furthermore, if the server is outside your local network, you should use FTPS or SFTP instead.
 
 For FTPS, if the server uses a "custom"/"self-signed" certificate chain, `keyFile` and `certFile` should be defined.
+
+### SFTP `sftp`
+
+ > In order to use this provider, you must install `paramiko`: `pip install paramiko` (you will also need the C compiler and _python dev_ package)
+
+This provider uses SFTP to upload the files to a server. Requires the host, an user and a authentication method to be able to connect.
+
+The authentication is attempted using the following order:
+
+- If `privateKey` or `privateKeyFile` is defined, then this method will be used. If the private key is cyphered, use `password` as the passphrase of the key.
+- If `allowAgent` is true, then will use the SSH Agent to connect to the server.
+- Any key in `~/.ssh`
+- If the `password` is defined, then the classic username/password login (discouraged)
+
+The known-hosts list is loaded by default from the default location `~/.ssh/known_hosts`. If `hostKeysFilePath` is defined, then this file will be used instead. If `disableHostKeys` is set to false, then no known-hosts will be loaded.
+
+The `knownHostsPolicy` will set the policy that will be used when the SSH connection is set, but the host is being checked as a known or not-known host. The following policies are allowed:
+
+- `reject` will close the connection if the host is not-known (default behaviour).
+- `auto-add` will add to the list of known-hosts if the host is not-known.
+- `ignore` will print a warning if the host is not-known.
+
+**Note**: if the `knownHostsPolicy` is `auto-add` and `hostKeysFilePath` is defined, then the new host will be saved into the file.
 
 
 ### Secrets backends

--- a/README.md
+++ b/README.md
@@ -120,27 +120,45 @@ This allows you to auto-complete with the elements available in the configuratio
     },
     "providers": [
         {
-            "type": "gdrive",
-            "backupsPath": "Path in Google Drive where the backups will be located",
-            "clientSecrets": "config/client_secrets.json",
-            "authTokens": "config/auth_tokens.json"
+          "type": "gdrive",
+          "backupsPath": "Path in Google Drive where the backups will be located",
+          "clientSecrets": "config/client_secrets.json",
+          "authTokens": "config/auth_tokens.json"
         },
         {
-            "type": "s3",
-            "backupsPath": "Path in S3 where the backups will be located",
-            "region": "Region of the S3 storage",
-            "endpoint": "Endpoint (if not set, uses Amazon S3 endpoint)",
-            "accessKeyId": "Access Key ID",
-            "accessSecretKey": "Access Secret Key",
-            "bucket": "Name of the bucket"
+          "type": "s3",
+          "backupsPath": "Path in S3 where the backups will be located",
+          "region": "Region of the S3 storage",
+          "endpoint": "Endpoint (if not set, uses Amazon S3 endpoint)",
+          "accessKeyId": "Access Key ID",
+          "accessSecretKey": "Access Secret Key",
+          "bucket": "Name of the bucket"
         },
         {
-            "type": "b2",
-            "backupsPath": "Path in B2 where the backups will be located",
-            "keyId": "B2 Key ID",
-            "appKey": "B2 Application Key",
-            "bucket": "Name of the bucket",
-            "password": "(optional) Protects files with passwords"
+          "type": "b2",
+          "backupsPath": "Path in B2 where the backups will be located",
+          "keyId": "B2 Key ID",
+          "appKey": "B2 Application Key",
+          "bucket": "Name of the bucket",
+          "password": "(optional) Protects files with passwords"
+        },
+        {
+          "type": "ftp",
+          "backupsPath": "Path in the FTP where the backups will be located",
+          "host": "Host (with or without the port) where the FTP server is located",
+          "user": "(optional) User to connect to the FTP server",
+          "password": "(optional) Password for the user",
+          "acct":  "(optional) Account information for the user"
+        },
+        {
+          "type": "ftps",
+          "backupsPath": "Path in the FTPS where the backups will be located",
+          "host": "Host (with or without the port) where the FTPS server is located",
+          "user": "(optional) User to connect to the FTPS server",
+          "password": "(optional) Password for the user",
+          "acct":  "(optional) Account information for the user",
+          "keyFile": "(optional) If needed, define a custom key file",
+          "certFile": "(optional) If needed, define a custom certificate file"
         }
     ],
     "hooks": {
@@ -193,6 +211,15 @@ The content type of the files will be guessed and set in the metadata when uploa
 The `backupsPath` in S3 is like a prefix for the file keys. It is recommended to put something here to easily organise the backups from the rest of files in the bucket. The initial slash `/` is removed when uploading the files.
 
 The content type of the files will be guessed and set in the metadata when uploading.
+
+#### FTP(S) `ftp` | `ftps`
+
+ > This provider does not need any extra package, uses `ftplib` from Python
+
+This provider uses FTP or FTPS to upload the files to a server. Requires the host to be able to connect. It is recommended to use an user and password for security reasons. Furthermore, if the server is outside your local network, you should use FTPS or SFTP instead.
+
+For FTPS, if the server uses a "custom"/"self-signed" certificate chain, `keyFile` and `certFile` should be defined.
+
 
 ### Secrets backends
 

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -373,7 +373,8 @@
               "s3",
               "b2",
               "ftp",
-              "ftps"
+              "ftps",
+              "sftp"
             ],
             "title": "Provider type",
             "default": ""

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -371,7 +371,9 @@
             "enum": [
               "gdrive",
               "s3",
-              "b2"
+              "b2",
+              "ftp",
+              "ftps"
             ],
             "title": "Provider type",
             "default": ""

--- a/mdbackup/__main__.py
+++ b/mdbackup/__main__.py
@@ -118,7 +118,7 @@ def main_upload_backup(logger: logging.Logger, config: Config, backup: Path):
 
     try:
         # Upload files to storage providers
-        backup_folder_name = backup.relative_to(config.backups_path).parts[0]
+        backup_folder_name = backup.relative_to(config.backups_path.resolve()).parts[0]
         for prov_config in config.providers:
             # Detect provider type and instantiate it
             storage = create_storage_instance(prov_config)
@@ -151,6 +151,7 @@ def main_upload_backup(logger: logging.Logger, config: Config, backup: Path):
                         logger.exception(f'Could not upload file {item}: {e}')
 
                 run_hook('upload:after', prov_config.type, str(backup), backup_cloud_folder)
+                del storage
             else:
                 # The provider is invalid, show error
                 logger.error(f'Unknown storage provider "{prov_config.type}", ignoring...')

--- a/mdbackup/check_packages/__init__.py
+++ b/mdbackup/check_packages/__init__.py
@@ -37,6 +37,13 @@ def check_pydrive(package: str):
         raise ImportError(f'To use {package}, you must install PyDrive: pip install PyDrive', e)
 
 
+def check_paramiko(package: str):
+    try:
+        from paramiko import SSHClient
+    except ImportError as e:
+        raise ImportError(f'To use {package}, you must install paramiko: pip install paramiko', e)
+
+
 def check(package: str, *funcs):
     def check_dec(func):
         @functools.wraps(func)

--- a/mdbackup/config.py
+++ b/mdbackup/config.py
@@ -43,6 +43,9 @@ class ProviderConfig(object):
         """
         return self.__backups_path
 
+    def __contains__(self, item: str):
+        return item in self.__extra
+
     def __getitem__(self, key: str):
         return self.__extra[key]
 

--- a/mdbackup/storage/__init__.py
+++ b/mdbackup/storage/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from mdbackup.check_packages import check, check_b2blaze, check_boto3, check_magic, check_pydrive
+from mdbackup.check_packages import check, check_b2blaze, check_boto3, check_magic, check_pydrive, check_paramiko
 from mdbackup.storage.storage import AbstractStorage, T
 
 
@@ -28,12 +28,19 @@ def load_ftp_storage(secure):
     return FTPSStorage if secure else FTPStorage
 
 
+@check('SFTP storage', check_paramiko)
+def load_sftp_storage():
+    from mdbackup.storage.sftp import SFTPStorage
+    return SFTPStorage
+
+
 __impls = {
     'gdrive': load_gdrive_storage,
     's3': load_s3_storage,
     'b2': load_backblaze_storage,
     'ftp': lambda: load_ftp_storage(False),
     'ftps': lambda: load_ftp_storage(True),
+    'sftp': load_sftp_storage,
 }
 
 

--- a/mdbackup/storage/ftp.py
+++ b/mdbackup/storage/ftp.py
@@ -33,8 +33,9 @@ class FTPStorage(AbstractStorage[Path]):
         self.__dir = Path(params.backups_path)
 
     def __del__(self):
-        self.__log.debug('Closing connection')
-        self.__conn.close()
+        if hasattr(self, '_FTPStorage__conn') or hasattr(self, '_FTPSStorage__conn'):
+            self.__log.debug('Closing connection')
+            self.__conn.close()
 
     def _create_connection(self, params: ProviderConfig):
         self.__log.debug('Creating connection to FTP server ' + params['host'])

--- a/mdbackup/storage/ftp.py
+++ b/mdbackup/storage/ftp.py
@@ -1,0 +1,80 @@
+# Small but customizable utility to create backups and store them in
+# cloud storage providers
+# Copyright (C) 2019  Melchor Alejo Garau Madrigal & Andrés Mateos García
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from ftplib import FTP, FTP_TLS
+import logging
+from pathlib import Path
+from typing import List, Union
+
+from mdbackup.config import ProviderConfig
+from mdbackup.storage.storage import AbstractStorage
+
+
+class FTPStorage(AbstractStorage[Path]):
+    def __init__(self, params: ProviderConfig):
+        self.__log = logging.getLogger(f'{__name__}:FTPStorage')
+        self.__conn = self._create_connection(params)
+
+        self.__conn.cwd(params.backups_path)
+        self.__dir = Path(params.backups_path)
+
+    def __del__(self):
+        self.__log.debug('Closing connection')
+        self.__conn.close()
+
+    def _create_connection(self, params: ProviderConfig):
+        self.__log.debug('Creating connection to FTP server ' + params['host'])
+        return FTP(host=params['host'],
+                   user=params.get('user'),
+                   passwd=params.get('password'),
+                   acct=params.get('acct'))
+
+    def list_directory(self, path: Union[str, Path]) -> List[Path]:
+        self.__log.debug(f'Retrieving contents of directory {path}')
+        return [filename for (filename, _) in self.__conn.mlsd(self.__dir / path)][2:]
+
+    def create_folder(self, name: str, parent: Union[Path, str] = None) -> Path:
+        path = self.__dir / parent
+        self.__conn.cwd(str(path))
+        if name not in self.list_directory(parent):
+            self.__log.info(f'Creating folder "{path / name}"')
+            self.__conn.mkd(name)
+        else:
+            self.__log.debug(f'Folder "{path / name}"" already exists')
+        return path / name
+
+    def upload(self, path: Path, parent: Union[Path, str] = None):
+        dir_path = self.__dir / parent
+        self.__conn.cwd(str(dir_path))
+        with open(path, 'rb') as file_to_upload:
+            self.__log.info(f'Uploading file {path} to {parent}')
+            self.__conn.storbinary(f'STOR {path.name}', file_to_upload)
+
+
+class FTPSStorage(FTPStorage):
+    def __init__(self, params: ProviderConfig):
+        super().__init__(params)
+        self.__log = logging.getLogger(f'{__name__}:FTPSStorage')
+
+    def _create_connection(self, params: ProviderConfig):
+        self.__log.debug('Creating connection to FTPS server ' + params['host'])
+        return FTP_TLS(host=params['host'],
+                       user=params.get('user'),
+                       passwd=params.get('password'),
+                       acct=params.get('acct'),
+                       keyfile=params.get('keyFile'),
+                       certfile=params.get('certFile'))

--- a/mdbackup/storage/sftp.py
+++ b/mdbackup/storage/sftp.py
@@ -1,0 +1,93 @@
+# Small but customizable utility to create backups and store them in
+# cloud storage providers
+# Copyright (C) 2019  Melchor Alejo Garau Madrigal & Andrés Mateos García
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from paramiko import SSHClient, SFTPClient, PKey, RejectPolicy, AutoAddPolicy, WarningPolicy
+import logging
+from pathlib import Path
+from typing import List, Union
+
+from mdbackup.config import ProviderConfig
+from mdbackup.storage.storage import AbstractStorage
+
+
+class SFTPStorage(AbstractStorage[Path]):
+    def __init__(self, params: ProviderConfig):
+        self.__log = logging.getLogger(__name__)
+        self.__conn = self._create_connection(params)
+
+        self.__conn.chdir(params.backups_path)
+        self.__dir = Path(params.backups_path)
+
+    def __del__(self):
+        if hasattr(self, '_SFTPStorage__conn'):
+            self.__log.debug('Closing connection')
+            self.__conn.close()
+
+    def _create_connection(self, params: ProviderConfig) -> SFTPClient:
+        self.__log.debug('Creating connection to SSH server ' + params['host'])
+        self.__ssh = SSHClient()
+        if 'disableHostKeys' not in params or params['disableHostKeys']:
+            self.__ssh.load_system_host_keys(filename=params.get('hostKeysFilePath'))
+
+        should_save_host_keys = False
+        if 'knownHostsPolicy' in params:
+            policy: str = params['knownHostsPolicy'].lower()
+            if policy == 'reject':
+                self.__ssh.set_missing_host_key_policy(RejectPolicy)
+            elif policy == 'auto-add':
+                self.__ssh.set_missing_host_key_policy(AutoAddPolicy)
+                should_save_host_keys = True
+            elif policy == 'ignore':
+                self.__ssh.set_missing_host_key_policy(WarningPolicy)
+
+        pkey = None
+        if 'privateKey' in params:
+            pkey = PKey(data=params['privateKey'])
+        self.__ssh.connect(hostname=params['host'],
+                           port=params.get('port', 22),
+                           username=params.get('user'),
+                           password=params.get('password'),
+                           pkey=pkey,
+                           key_filename=params.get('privateKeyPath'),
+                           allow_agent=params.get('allowAgent'),
+                           compress=params.get('compress'))
+
+        if should_save_host_keys and 'hostKeysFilePath' in params:
+            self.__ssh.save_host_keys(filename=params['hostKeysFilePath'])
+
+        self.__log.debug('Starting SFTP client')
+        return self.__ssh.open_sftp()
+
+    def list_directory(self, path: Union[str, Path]) -> List[Path]:
+        self.__log.debug(f'Retrieving contents of directory {path}')
+        return self.__conn.listdir(path)
+
+    def create_folder(self, name: str, parent: Union[Path, str] = None) -> Path:
+        path = self.__dir / parent
+        self.__conn.chdir(str(path))
+        if name not in self.list_directory(parent):
+            self.__log.info(f'Creating folder "{path / name}"')
+            self.__conn.mkdir(name)
+        else:
+            self.__log.debug(f'Folder "{path / name}"" already exists')
+        return path / name
+
+    def upload(self, path: Path, parent: Union[Path, str] = None):
+        dir_path = self.__dir / parent
+        self.__conn.chdir(str(dir_path))
+        self.__log.info(f'Uploading file {path} to {parent}')
+        self.__conn.put(str(path), path.name, confirm=True)


### PR DESCRIPTION
This PR adds support to FTP, FTPS and SFTP as storage providers, in order to use one of this kind of servers to upload the backups. It also includes some fixes.

## FTP
Uses the Python package `ftplib` to connect to a FTP server and upload files. Simple yet powerful implementation. Has the following specific parameters:
- `host`: Host (with or without the port) where the FTP server is located
- `user`: _(optional)_ User to connect to the FTP server
- `password`: _(optional)_ Password for the user
- `acct`:  _(optional)_ Account information for the user

## FTPS
Extends the FTP implementation by using FTP over SSL/TLS, and receiving the same parameters plus:
- `keyFile`: _(optional)_ If needed, define a custom key file
- `certFile`: _(optional)_ If needed, define a custom certificate file

## SFTP
Uses the package [`paramiko`](http://docs.paramiko.org/en/2.4/index.html) to connect to an SSH server and then ask for a SFTP session. Is able to interact with the system `~/.ssh/known_hosts` and SSH Agent (if desired), and can use the private key found at `~/.ssh/id_rsa` to connect to the server or use a custom private key. _btw, this is the preferred method to upload files of the three of this PR._

These are the specific parameters for SFTP provider:
- `host`: Host where the SFTP server is located
- `port`: _(optional)_ Port of the SFTP server (by default 22)
- `user`: User to connect to the SFTP server
- `password`: _(optional)_ Password for the user
- `privateKey`: _(optional)_ Private Key in base64
- `privateKeyPath`: _(optional)_ Private Key file path
- `allowAgent`: _(optional)_ if true, then the connection will interact with the SSH Agent, false if this behaviour is not desired (false by default)
- `compress`: _(optional)_ if true, then the connection is compressed (false by default)
- `knownHostsPolicy`: _(optional)_ Changes the Known Hosts Policy. 'reject' will reject any connection to a server that is not known (default behaviour), 'auto-add' will add to the known-hosts list this server, 'ignore' will print a warning but it will let you connect.
- `hostKeysFilePath`: _(optional)_ Path to the known-hosts file
- `disableHostKeys`: _(optional)_ If set to false, it won't load any known-hosts file (by default is true)

The authentication is attempted using the following order:
- If `privateKey` or `privateKeyFile` is defined, then this method will be used. If the private key is cyphered, use `password` as the passphrase of the key.
- If `allowAgent` is true, then will use the SSH Agent to connect to the server.
- Any key in `~/.ssh`
- If the `password` is defined, then the classic username/password login (discouraged)

The known-hosts list is loaded by default from the default location `~/.ssh/known_hosts`. If `hostKeysFilePath` is defined, then this file will be used instead. If `disableHostKeys` is set to false, then no known-hosts will be loaded.

The `knownHostsPolicy` will set the policy that will be used when the SSH connection is set, but the host is being checked as a known or not-known host. The following policies are allowed:
- `reject` will close the connection if the host is not-known (default behaviour).
- `auto-add` will add to the list of known-hosts if the host is not-known.
- `ignore` will print a warning if the host is not-known.

## Fixes

- If the backups folder is a symbolic link, then it will be resolved in order to get the right relative path for the current backup when uploaded.
- If any provider raises a `KeyError` in their `__init__` method, then it will be properly raised to the top of the stack, instead of returning `None` indicating that this provider does not exist.
- The `in` operator over a `ProviderConfig` could fail in some scenarios. Implemented the magic `__contains__` method in `ProviderConfig` to avoid the failure.
- The storage provider is `del`eted  after being used, just in case the provider needs to clean up stuff (like in FTP, FTPS and SFTP implementations).