### PR TITLE
Improve Secrets configuration

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -202,13 +202,26 @@
                 }
               }
             },
-            "providers": {
-              "$id": "#/properties/secrets/properties/file/properties/providers",
+            "storage": {
+              "$id": "#/properties/secrets/properties/file/properties/storage",
               "type": "array",
               "title": "Configure cloud storage providers from json files",
               "examples": [
                 [ "secret/backups/providers/digitalocean", "secret/backups/providers/backblaze" ]
-              ]
+              ],
+              "items": {
+                "$id": "#/properties/secrets/properties/file/properties/storage/items",
+                "type": [ "object", "string" ],
+                "title": "A key to access the secret or an object with the key and options to be added/overwrote from the configuration",
+                "required": [ "key" ],
+                "properties": {
+                  "key": {
+                    "$id": "#/properties/secrets/properties/file/properties/storage/items/properties/key",
+                    "type": "string",
+                    "title": "A key to access the secret"
+                  }
+                }
+              }
             }
           }
         },
@@ -259,13 +272,26 @@
                 }
               }
             },
-            "providers": {
-              "$id": "#/properties/secrets/properties/vault/properties/providers",
+            "storage": {
+              "$id": "#/properties/secrets/properties/vault/properties/storage",
               "type": "array",
               "title": "Configure cloud storage providers securely from Vault",
               "examples": [
                 [ "secret/backups/providers/digitalocean", "secret/backups/providers/backblaze" ]
-              ]
+              ],
+              "items": {
+                "$id": "#/properties/secrets/properties/vault/properties/storage/items",
+                "type": [ "object", "string" ],
+                "title": "A key to access the secret or an object with the key and options to be added/overwrote from the configuration",
+                "required": [ "key" ],
+                "properties": {
+                  "key": {
+                    "$id": "#/properties/secrets/properties/vault/properties/storage/items/properties/key",
+                    "type": "string",
+                    "title": "A key to access the secret"
+                  }
+                }
+              }
             }
           }
         }

--- a/mdbackup/config.py
+++ b/mdbackup/config.py
@@ -55,11 +55,11 @@ class ProviderConfig(object):
 
 class SecretConfig(object):
     def __init__(self, secret_type: str, secret_env: Optional[Dict[str, str]], secret_config: Dict[str, any],
-                 secret_providers: Optional[List[str]]):
+                 secret_storage: Optional[List[str]]):
         self.__type = secret_type
         self.__config = secret_config
         self.__env = secret_env if secret_env is not None else {}
-        self.__providers = secret_providers if secret_providers is not None else []
+        self.__storage = secret_storage if secret_storage is not None else []
 
     @property
     def type(self) -> str:
@@ -74,8 +74,8 @@ class SecretConfig(object):
         return self.__env
 
     @property
-    def providers(self) -> List[str]:
-        return self.__providers
+    def storage(self) -> List[Union[str, Dict[str, str]]]:
+        return self.__storage
 
 
 class Config(object):

--- a/mdbackup/secrets/secrets.py
+++ b/mdbackup/secrets/secrets.py
@@ -27,3 +27,6 @@ class AbstractSecretsBackend(ABC):
     @abstractmethod
     def get_provider(self, key: str) -> Dict[str, any]:
         pass
+
+    def __del__(self):
+        pass

--- a/mdbackup/secrets/vault_backend.py
+++ b/mdbackup/secrets/vault_backend.py
@@ -53,3 +53,8 @@ class VaultSecretsBackend(AbstractSecretsBackend):
 
     def get_provider(self, key: str) -> Dict[str, any]:
         return self.__kv_get(key)['data']
+
+    def __del__(self):
+        requests.post(f'{self._api}/v1/auth/token/revoke-self', headers={'X-Vault-Token': self._client_token},
+                      verify=self._cert)
+        self._client_token = None


### PR DESCRIPTION
Now from the configuration, you can define new values or overwrite values from the storage provider configuration obtained from the secret backend. For example, this is useful to have the same credentials for a storage provider be used in different servers, but each will have their own `backupsPath`.

The configuration now supports a string or an object with key and more properties.