### PR TITLE
(Almost all) unactions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         docker {
           label 'docker'
           image 'python:3.7-buster'
-          args '-e HOME=$WORKSPACE -e PATH=$PATH:$WORKSPACE/.local/bin'
+          args '-e HOME=$WORKSPACE -e PATH=$PATH:$WORKSPACE/.local/bin -v $HOME/caches:$HOME/caches'
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         docker {
           label 'docker'
           image 'python:3.7-buster'
-          args '-e HOME=$WORKSPACE -e PATH=$PATH:$WORKSPACE/.local/bin -v $HOME/caches:$HOME/caches'
+          args '-e HOME=$WORKSPACE -e PATH=$PATH:$WORKSPACE/.local/bin'
         }
       }
 

--- a/docs/actions/archive.md
+++ b/docs/actions/archive.md
@@ -6,6 +6,8 @@
 
 **Output**: stream
 
+**Unaction**: yes
+
 **Parameters**
 
 ignored (you can pass whatever you want 🙃)

--- a/docs/actions/command.md
+++ b/docs/actions/command.md
@@ -6,6 +6,10 @@
 
 **Output**: stream
 
+**Unaction**:
+
+Yes, but to make it work, you need to defined the reverse command. To do so, just define a new section called `reverse` with `args` or `command` (see example below). If trying to do a restore with no `reverse.args` nor `reverse.command` will result in a failure.
+
 **Parameters**
 
 Can be a `str` or an object. The string will be interpreted as a sh-like command, the object with the folliwing structure:
@@ -20,7 +24,7 @@ Can be a `str` or an object. The string will be interpreted as a sh-like command
 
 Executes the command that produces an output, and may receive an input. The command can be defined by either using `args` or `command` parameter. If needed, the command can run with extra environment variables defined in the `env` parameter. The current working directory will be the backup path. The parameter can also be a string, in this case will be interpreted as `command` parameter.
 
-!!! Example
+!!! Example "Example of command as initial action"
     Does a backup of a partition and then compresses it.
 
     ```yaml
@@ -32,7 +36,7 @@ Executes the command that produces an output, and may receive an input. The comm
             path: 'full-backup.gz'
     ```
 
-!!! Example
+!!! Example "Example of command as transform action"
     Does a backup of a file transforming all instances of `A` to `a` (using `sed`).
 
     ```yaml
@@ -44,12 +48,29 @@ Executes the command that produces an output, and may receive an input. The comm
             path: 'transformed-backup.txt'
     ```
 
+!!! Example "Example of command with `reverse`"
+    Does a backup of some program that exports its data using a CLI tool, but also defining how to restore the data.
+
+    ```yaml
+    - name: command task example 3
+      actions:
+        - command:
+            command: 'tool-cli export -'
+            reverse:
+              command: 'tool-cli import -'
+        - compress-zst: {}
+        - to-file:
+            path: 'tool-data.zst'
+    ```
+
 
 ## `ssh`
 
 **Input**: Nothing or stream
 
 **Output**: stream
+
+**Unaction**: See [command](#command) *unaction* section.
 
 **Parameters**
 
@@ -96,6 +117,8 @@ Executes the command through ssh, in another host, which must produce an output 
 **Input**: Nothing or stream
 
 **Output**: stream
+
+**Unaction**: See [command](#command) *unaction* section.
 
 **Parameters**
 

--- a/docs/actions/compress.md
+++ b/docs/actions/compress.md
@@ -6,6 +6,8 @@
 
 **Output**: stream
 
+**Unaction**: yes
+
 **Parameters**
 
 | Name | Type | Description | Optional |
@@ -45,6 +47,8 @@ This compression algorithm uses huge amount of CPU and the result is usually bet
 
 **Output**: stream
 
+**Unaction**: yes
+
 **Parameters**
 
 | Name | Type | Description | Optional |
@@ -79,6 +83,8 @@ This compression algorithm is rather fast and good-balanced in resources consump
 **Input**: stream
 
 **Output**: stream
+
+**Unaction**: yes
 
 **Parameters**
 
@@ -115,6 +121,8 @@ This compression algorithm is rather fast and good-balanced in resources consump
 
 **Output**: stream
 
+**Unaction**: yes
+
 **Parameters**
 
 | Name | Type | Description | Optional |
@@ -141,4 +149,41 @@ This compression algorithm is fast and good-balanced in resources consumption. C
             compressionLevel: 7
         - to-file:
             path: 'compressed-file.br'
+    ```
+
+
+## `compress-zst`
+
+**Input**: stream
+
+**Output**: stream
+
+**Unaction**: yes
+
+**Parameters**
+
+| Name | Type | Description | Optional |
+|------|------|-------------|----------|
+| `compressionLevel` | `ìnt` | Compression level from 1 to 19 (default 3) | Yes |
+
+**Description**
+
+Compresses the input stream using `zstd` utility. If the compression level increases, more resources will be used to compress and more compressed the file should result (it may not compress any further if increasing it to 19).
+
+This compression algorithm is blazing fast and good in compression (similar to `xz` but faster). Can be used as a fast compression algorithm for text and binary files.
+
+!!! Warning
+    Requires `zstd` to be installed in the system. On Debian-based distros use `apt install zstd`, on Arch-based distros use `pacman -S zstd`, on macOS use `brew install zstd`.
+
+!!! Example
+    Compresses a file using `zstd`
+
+    ```yaml
+    - name: zst task example
+      actions:
+        - from-file: '/big/compressible/file'
+        - compress-zst:
+            compressionLevel: 7
+        - to-file:
+            path: 'compressed-file.zst'
     ```

--- a/docs/actions/database.md
+++ b/docs/actions/database.md
@@ -6,6 +6,8 @@
 
 **Output**: stream
 
+**Unaction**: To be implemented...
+
 **Parameters**:
 
 | Name | Type | Description | Optional |
@@ -66,6 +68,8 @@ Uses `pg_dump` to make a full backup of a PostgreSQL database into a SQL file. B
 **Input**: Nothing
 
 **Output**: stream
+
+**Unaction**: To be implemented...
 
 **Parameters**
 
@@ -130,6 +134,8 @@ Uses `mysqldump` to make a full backup of a MySQL/MariaDB database into a SQL fi
 **Input**: Nothing
 
 **Output**: Nothing
+
+**Unaction**: To be implemented...
 
 **Parameters**
 

--- a/docs/actions/directory.md
+++ b/docs/actions/directory.md
@@ -6,6 +6,8 @@
 
 **Output**: directory
 
+**Unaction**: Yes (Only works when using `dictionary` parameter - if using a `string` as parameter the restore will fail).
+
 **Parameters**
 
 | Name | Type | Description | Optional |
@@ -38,6 +40,8 @@ Reads the contents of the folder to be used in another action. By default, the s
 **Input**: Nothing
 
 **Output**: directory
+
+**Unaction**: Yes (Only works when using `dictionary` parameter - if using a `string` as parameter the restore will fail).
 
 **Parameters**
 
@@ -74,6 +78,8 @@ Determines which is the path to the folder of the desired volume (using `docker 
 **Input**: directory
 
 **Output**: Nothing
+
+**Unaction**: Yes
 
 **Parameters**
 
@@ -116,6 +122,8 @@ Writes the full contents of the folder into the folder defined in `path` (which 
 **Input**: Nothing
 
 **Output**: Nothing
+
+**Unaction**: Yes
 
 **Parameters**
 

--- a/docs/actions/encrypt.md
+++ b/docs/actions/encrypt.md
@@ -6,19 +6,22 @@
 
 **Output**: stream
 
+**Unaction**: yes
+
 **Parameters**
 
 | Name | Type | Description | Optional |
 |------|------|-------------|----------|
 | `passphrase` | `str` | Defines a passphrase that will be used to decrypt the data | Yes |
 | `recipients` | `List[str]` | List of emails that will be able to decrypt the data | Yes |
-| `algorithm` | `str` | Changes the cypher algorithm | Yes |
+| `cipherAlgorithm` | `str` | Changes the cypher algorithm | Yes |
+| `compressAlgorithm` | `str` | Changes the compress algorithm | Yes |
 
 At least one recipient must be defined. If no recipients are defined, a passphrase must be provided. Both can be defined.
 
 **Description**
 
-Encrypts the data using `gpg` (gpg 2) command. If recipients are defined, then the users that own that keys will be able to decrypt the data. If passphrase is defined, then this passphrase will be used to encrypt the data. Both can be defined so if a user owns a key and is able to decrypt the data, the passphrase will be asked as well.
+Encrypts the data using `gpg` (gpg 2) command. If recipients are defined, then the users that own that keys will be able to decrypt the data. If passphrase is defined, then this passphrase will be used to encrypt the data. Both can be defined so if a user owns a key and is able to decrypt the data, the passphrase will be asked as well. The cipher and compress valid algorithms can be queried by issuing the command `gpg --version`. By default the compress algorithm is `uncompressed`.
 
 !!! Warning
     The recipient keys must be imported previously. The action will not import any key.

--- a/docs/actions/file.md
+++ b/docs/actions/file.md
@@ -6,6 +6,8 @@
 
 **Output**: stream
 
+**Unaction**: Yes
+
 **Parameters**
 
 Expects a path as string or an object like `{ path: '/path/to/file' }`.
@@ -31,6 +33,8 @@ Initial action that opens a file to be read from the next actions. The user runn
 **Input**: Nothing
 
 **Output**: stream
+
+**Unaction**: Yes
 
 **Parameters**
 
@@ -75,6 +79,8 @@ Reads a file from the remote server using `scp`, and the output can be used in o
 
 **Output**: Nothing
 
+**Unaction**: Yes
+
 **Parameters**
 
 | Name | Type | Description | Optional |
@@ -105,6 +111,8 @@ Writes the data stream into a file, reading chunks of `chunkSize` bytes until en
 **Input**: Nothing
 
 **Output**: Nothing
+
+**Unaction**: Yes
 
 **Parameters**
 
@@ -142,6 +150,8 @@ Copies a file to the backup folder. It is an optimized version in which the prev
 **Input**: Nothing
 
 **Output**: Nothing
+
+**Unaction**: Yes
 
 **Parameters**
 

--- a/docs/actions/network.md
+++ b/docs/actions/network.md
@@ -8,6 +8,8 @@
 
 **Output**: stream
 
+**Unaction**: No
+
 **Parameters**
 
 | Name | Type | Description | Optional |
@@ -62,6 +64,8 @@ Does a backup from an AsusWRT router through its web admin panel. The file is do
 **Input**: Nothing
 
 **Output**: stream
+
+**Unaction**: No
 
 **Parameters**
 

--- a/mdbackup/actions/builtin/archive.py
+++ b/mdbackup/actions/builtin/archive.py
@@ -39,7 +39,7 @@ def action_untar(stream, params) -> DirEntryGenerator:
     tar = tarfile.open(mode='r|', fileobj=stream)
     for tar_info in tar:
         tar_info: tarfile.TarInfo
-        if tar_info.isdir() or tar_info.islnk() or tar_info.isreg():
+        if tar_info.isdir() or tar_info.islnk() or tar_info.issym():
             yield DirEntry.from_tar_info(tar_info)
         elif tar_info.isreg():
             yield DirEntry.from_tar_info(tar_info, stream=tar.extractfile(tar_info))

--- a/mdbackup/actions/builtin/command.py
+++ b/mdbackup/actions/builtin/command.py
@@ -16,16 +16,22 @@ def reverse_action(func):
     def impl(inp, params: dict):
         logger = logging.getLogger(__name__).getChild(func.__name__ + '_reversed')
         new_params = params.copy()
+        if 'reverse' not in params:
+            raise ValueError('no reverse option is defined')
         args = params['reverse'].get('args')
         command = params['reverse'].get('command')
         if args is not None:
             new_params['args'] = args
+            if 'command' in new_params:
+                del new_params['command']
         elif command is not None:
             new_params['command'] = command
+            if 'args' in new_params:
+                del new_params['args']
         else:
-            raise KeyError('no reverse args nor command defined')
+            raise ValueError('no reverse args nor command defined')
         logger.debug('Next command is run reversed')
-        return func(inp, params)
+        return func(inp, new_params)
 
     return impl
 

--- a/mdbackup/actions/builtin/compress.py
+++ b/mdbackup/actions/builtin/compress.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from mdbackup.actions.builtin.command import action_command
-from mdbackup.actions.container import action
+from mdbackup.actions.container import action, unaction
 from mdbackup.actions.ds import InputDataStream
 
 
@@ -23,6 +23,17 @@ def action_compress_xz(inp: InputDataStream, params) -> subprocess.Popen:
     return action_command(inp, {'args': args})
 
 
+@unaction('compress-xz')
+def action_decompress_xz(inp: InputDataStream, params) -> subprocess.Popen:
+    cpus = params.get('cpus')
+
+    args = ['xz', '-d']
+    if cpus is not None:
+        args.extend(['-T', str(cpus)])
+
+    return action_command(inp, {'args': args})
+
+
 @action('compress-gz', input='stream', output='stream:process')
 def action_compress_gzip(inp: InputDataStream, params) -> subprocess.Popen:
     compression_level = params.get('compressionLevel')
@@ -32,6 +43,11 @@ def action_compress_gzip(inp: InputDataStream, params) -> subprocess.Popen:
         args.append(f'-{compression_level}')
 
     return action_command(inp, {'args': args})
+
+
+@unaction('compress-gz')
+def action_decompress_gz(inp: InputDataStream, _) -> subprocess.Popen:
+    return action_command(inp, {'args': ['gzip', '-d']})
 
 
 @action('compress-bz2', input='stream', output='stream:process')
@@ -45,6 +61,11 @@ def action_compress_bzip2(inp: InputDataStream, params) -> subprocess.Popen:
     return action_command(inp, {'args': args})
 
 
+@unaction('compress-bz2')
+def action_decompress_bz2(inp: InputDataStream, _) -> subprocess.Popen:
+    return action_command(inp, {'args': ['bzip2', '-d', '-c']})
+
+
 @action('compress-br', input='stream', output='stream:process')
 def action_compress_brotli(inp: InputDataStream, params) -> subprocess.Popen:
     compression_level = params.get('compressionLevel')
@@ -52,5 +73,35 @@ def action_compress_brotli(inp: InputDataStream, params) -> subprocess.Popen:
     args = ['brotli', '-c']
     if 'compressionLevel' in params:
         args.append(f'-{compression_level}')
+
+    return action_command(inp, {'args': args})
+
+
+@unaction('compress-br')
+def action_decompress_brotli(inp: InputDataStream, _) -> subprocess.Popen:
+    return action_command(inp, {'args': ['brotli', '-d', '-c']})
+
+
+@action('compress-zst', input='stream', output='stream:process')
+def action_compress_zstd(inp: InputDataStream, params) -> subprocess.Popen:
+    cpus = params.get('cpus')
+    compression_level = params.get('compressionLevel')
+
+    args = ['zstd']
+    if cpus is not None:
+        args.append(f'-T{cpus}')
+    if compression_level is not None:
+        args.append(f'-{compression_level}')
+
+    return action_command(inp, {'args': args})
+
+
+@unaction('compress-zst')
+def action_decompress_zstd(inp: InputDataStream, params) -> subprocess.Popen:
+    cpus = params.get('cpus')
+
+    args = ['zstd', '-d']
+    if cpus is not None:
+        args.append(f'-T{cpus}')
 
     return action_command(inp, {'args': args})

--- a/mdbackup/actions/builtin/encrypt.py
+++ b/mdbackup/actions/builtin/encrypt.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from mdbackup.actions.builtin.command import action_command
-from mdbackup.actions.container import action
+from mdbackup.actions.container import action, unaction
 from mdbackup.actions.ds import InputDataStream
 from mdbackup.utils import raise_if_type_is_incorrect
 
@@ -10,11 +10,13 @@ from mdbackup.utils import raise_if_type_is_incorrect
 def action_encrypt_opengpg(inp: InputDataStream, params) -> subprocess.Popen:
     passphrase = params.get('passphrase')
     recipients: list = params.get('recipients', [])
-    algorithm = params.get('algorithm')
+    algorithm = params.get('cipherAlgorithm')
+    compress = params.get('compressAlgorithm', False)
 
     raise_if_type_is_incorrect(passphrase, str, 'passphrase must be a string')
     raise_if_type_is_incorrect(recipients, list, 'recipients must be a list of strings')
-    raise_if_type_is_incorrect(algorithm, str, 'algorithm must be a list of strings')
+    raise_if_type_is_incorrect(algorithm, str, 'cipherAlgorithm must be a string')
+    raise_if_type_is_incorrect(compress, str, 'compressAlgorithm must be a string')
 
     args = ['gpg', '--output', '-', '--batch']
     if passphrase:
@@ -26,6 +28,29 @@ def action_encrypt_opengpg(inp: InputDataStream, params) -> subprocess.Popen:
         args.append('--symmetric')
     if algorithm is not None:
         args.extend(['--cipher-algo', algorithm])
+    if isinstance(compress, str):
+        args.extend(['--compress-algo', compress])
+    else:
+        args.extend(['--compress-algo', 'uncompressed'])
+    args.append('-')
+
+    return action_command(inp, {'args': args})
+
+
+@unaction('encrypt-gpg')
+def action_decrypt_opengpg(inp: InputDataStream, params) -> subprocess.Popen:
+    passphrase = params.get('passphrase')
+    recipients: list = params.get('recipients', [])
+
+    raise_if_type_is_incorrect(passphrase, str, 'passphrase must be a string')
+    raise_if_type_is_incorrect(recipients, list, 'recipients must be a list of strings')
+
+    args = ['gpg', '--output', '-', '--batch', '-d']
+    if passphrase:
+        args.extend(['--passphrase', passphrase])
+    for recipient in recipients:
+        raise_if_type_is_incorrect(recipient, str, f'recipient {recipient} is not a string')
+        args.extend(['-r', recipient])
     args.append('-')
 
     return action_command(inp, {'args': args})

--- a/mdbackup/actions/builtin/file.py
+++ b/mdbackup/actions/builtin/file.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from mdbackup.actions.builtin._os_utils import _preserve_stats, _read_xattrs
 from mdbackup.actions.builtin.command import action_command
-from mdbackup.actions.container import action
+from mdbackup.actions.container import action, unaction
 from mdbackup.actions.ds import InputDataStream
 from mdbackup.utils import raise_if_type_is_incorrect
 
@@ -17,8 +17,7 @@ def action_read_file(_, params) -> io.FileIO:
     return open(params['path'] if isinstance(params, dict) else str(params), 'rb', buffering=0)
 
 
-@action('from-file-ssh', output='stream:process')
-def action_read_file_from_ssh(_, params):
+def _parse_ssh_args(params: dict):
     logger = logging.getLogger(__name__).getChild('action_read_file_from_ssh')
     args = []
     env = {}
@@ -57,12 +56,29 @@ def action_read_file_from_ssh(_, params):
     if config_file is not None:
         args.extend(['-F', config_file])
 
-    args.append(f"{params['host']}:{params['path']}")
+    remote = f"{params['host']}:{params['path']}"
     if user is not None:
-        args[-1] = f"{user}@{args[-1]}"
+        remote = f'{user}@{remote}'
 
+    return args, env, remote
+
+
+@action('from-file-ssh', output='stream:process')
+def action_read_file_from_ssh(_, params):
+    args, env, remote = _parse_ssh_args(params)
+
+    args.append(remote)
     args.append('/dev/stdout')
     return action_command(None, {'args': args, 'env': env})
+
+
+@unaction('from-file-ssh')
+def action_write_file_to_ssh(inp: InputDataStream, params):
+    args, env, remote = _parse_ssh_args(params)
+
+    args.append('/dev/stdin')
+    args.append(remote)
+    return action_command(inp, {'args': args, 'env': env})
 
 
 def _checks(params: dict) -> Path:
@@ -90,20 +106,41 @@ def _file_has_changed(entry, old_file: Path) -> bool:
     return mod_time_current != mod_time_prev
 
 
+def _write_file(inp: InputDataStream, out, chunk_size):
+    raise_if_type_is_incorrect(chunk_size, int, 'chunkSize is not a string')
+    data = inp.read(chunk_size)
+    while data is not None and len(data) != 0:
+        out.write(data)
+        data = inp.read(chunk_size)
+    out.close()
+
+
 @action('to-file', input='stream')
 def action_write_file(inp: InputDataStream, params):
     full_path = _checks(params)
 
     file_object = open(full_path, 'wb', buffering=0)
     chunk_size = params.get('chunkSize', 1024 * 8)
-    raise_if_type_is_incorrect(chunk_size, int, 'chunkSize is not a string')
-    data = inp.read(chunk_size)
-    while data is not None and len(data) != 0:
-        file_object.write(data)
-        data = inp.read(chunk_size)
-    file_object.close()
+    _write_file(inp, file_object, chunk_size)
 
     return full_path
+
+
+@unaction('to-file')
+def action_reverse_write_file(inp: InputDataStream, params):
+    if 'path' not in params:
+        params['path'] = params['to']
+    params['path'] = Path(params['_backup_path']) / params['path']
+    return action_read_file(inp, params)
+
+
+@unaction('from-file')
+def action_reverse_read_file(inp: InputDataStream, params):
+    if isinstance(params, str):
+        params = {'path': params}
+    file_object = open(params['path'], 'wb', buffering=0)
+    chunk_size = params.get('chunkSize', 1024 * 8)
+    _write_file(inp, file_object, chunk_size)
 
 
 @action('copy-file')
@@ -150,11 +187,42 @@ def action_copy_file(_, params: dict):
             },
         )
 
-    if preserve_stats and orig_path is not None:
-        xattrs = _read_xattrs(orig_path)
+    if preserve_stats:
+        xattrs = _read_xattrs(orig_path) if orig_path is not None else None
         _preserve_stats(dest_path, orig_stat, xattrs, preserve_stats)
 
     return dest_path
+
+
+@unaction('copy-file')
+def action_reverse_copy_file(_, params: dict):
+    logger = logging.getLogger(__name__).getChild('action_reverse_copy_file')
+    dest_path = Path(params['from'])
+    orig_path = _checks(params) if 'to' in params or 'path' in params else None
+    orig_stream = params.get('_stream')
+    orig_stat = orig_path.stat() if orig_path is not None else params['_stat']
+    preserve_stats = params.get('preserveStats', 'utime')
+
+    raise_if_type_is_incorrect(preserve_stats, (str, bool), 'preserveStats must be a string or a boolean')
+
+    avoid_copy = False
+    if not params.get('forceCopy', False):
+        logger.debug(f'Checking if the file can be needs to be copied')
+        avoid_copy = not _file_has_changed(orig_stat, dest_path) if dest_path.exists() else False
+
+    if avoid_copy:
+        logger.debug('File will not be copied')
+    else:
+        logger.debug(f'Copying file {orig_path if orig_path is not None else "*stream*"} to {dest_path}')
+        _write_file(
+            open(orig_path, 'rb', buffering=0) if orig_path is not None else orig_stream,
+            open(dest_path, 'wb', buffering=0),
+            params.get('chunkSize', 1024 * 8),
+        )
+
+    if preserve_stats:
+        xattrs = _read_xattrs(orig_path) if orig_path is not None else None
+        _preserve_stats(dest_path, orig_stat, xattrs, preserve_stats)
 
 
 @action('clone-file')
@@ -199,3 +267,14 @@ def action_clone_file(_, params: dict):
         os.link(str(orig_path), str(dest_path))
 
     return dest_path
+
+
+@unaction('clone-file')
+def action_reverse_clone_file(_, params: dict):
+    orig = params['from']
+    dest = params.get('path', params.get('to'))
+    params['from'] = dest
+    params['to'] = orig
+    if 'path' in params:
+        del params['path']
+    return action_clone_file(None, params)

--- a/mdbackup/actions/container.py
+++ b/mdbackup/actions/container.py
@@ -159,6 +159,8 @@ def unaction(identifier: str):
     def _unaction_impl(func):
         if identifier not in _actions:
             raise SystemError(f'Cannot register unaction {identifier} before registering its action counterpart')
+        if callable(_actions[identifier].unaction):
+            raise SystemError(f'Cannot register again an already registered unaction for action {identifier}')
 
         _actions[identifier].unaction = func
 

--- a/mdbackup/actions/ds.py
+++ b/mdbackup/actions/ds.py
@@ -57,7 +57,7 @@ class DirEntry:
 
     @staticmethod
     def from_tar_info(tar_info, **kwargs) -> 'DirEntry':
-        stats = os.stat_result()
+        stats = StatResult()
         stats.st_mode = tar_info.mode
         stats.st_uid = tar_info.uid
         stats.st_gid = tar_info.gid
@@ -89,3 +89,19 @@ DirEntryAction = Callable[[dict], DirEntryGenerator]
 DirEntryTransformAction = Callable[[DirEntryGenerator, dict], DirEntryGenerator]
 DirEntryToDataStreamTransformAction = Callable[[DirEntryGenerator, dict], OutputDataStream]
 DirEntryFinalAction = Callable[[DirEntryGenerator, dict], None]
+
+
+class StatResult:
+    st_mode: int = 0
+    st_ino: int = 0
+    st_dev: int = 0
+    st_nlink: int = 0
+    st_uid: int = 0
+    st_gid: int = 0
+    st_size: int = 0
+    st_atime: float = 0.0
+    st_mtime: float = 0.0
+    st_ctime: float = 0.0
+    st_atime_ns: int = 0
+    st_mtime_ns: int = 0
+    st_ctime_ns: int = 0

--- a/tests/actions/runner/run_task_unactions_tests.py
+++ b/tests/actions/runner/run_task_unactions_tests.py
@@ -22,7 +22,7 @@ def _register_actions(this=None):
         this._middle_stream_mock.stderr = MagicMock(spec=FileIO)
         this._middle_stream_mock.wait.return_value = 0
         register_action('final', nop, lambda _1, _2: this._initial_stream_mock, expected_input='stream')
-        register_action('middle', nop, lambda _1, _2: this._middle_stream_mock, expected_input='stream', output='stream')
+        register_action('middle', nop, lambda _, _2: this._middle_stream_mock, expected_input='stream', output='stream')
     else:
         register_action('final', nop, lambda _1, _2: None, expected_input='stream')
         register_action('middle', nop, lambda _1, _2: None, expected_input='stream', output='stream')

--- a/tests/actions/runner/run_task_unactions_tests.py
+++ b/tests/actions/runner/run_task_unactions_tests.py
@@ -1,0 +1,152 @@
+from io import FileIO
+from subprocess import Popen
+from unittest.mock import MagicMock, Mock
+
+from tests.classes import TestCaseWithoutLogs
+
+from mdbackup.actions.container import _clean_actions, register_action
+from mdbackup.actions.runner import run_task_unactions
+
+
+def _failure_impl(_1, _2):
+    raise KeyError('f')
+
+
+def _register_actions(this=None):
+    def nop():
+        pass
+    if this is not None:
+        this._initial_stream_mock = Mock(spec=FileIO)
+        this._middle_stream_mock = Mock(spec=Popen)
+        this._middle_stream_mock.stdout = MagicMock(spec=FileIO)
+        this._middle_stream_mock.stderr = MagicMock(spec=FileIO)
+        this._middle_stream_mock.wait.return_value = 0
+        register_action('final', nop, lambda _1, _2: this._initial_stream_mock, expected_input='stream')
+        register_action('middle', nop, lambda _1, _2: this._middle_stream_mock, expected_input='stream', output='stream')
+    else:
+        register_action('final', nop, lambda _1, _2: None, expected_input='stream')
+        register_action('middle', nop, lambda _1, _2: None, expected_input='stream', output='stream')
+    register_action('initial', nop, lambda _1, _2: None, output='stream')
+    register_action('initial-with-no-unaction', nop)
+    register_action('ifailure', nop, _failure_impl, output='stream')
+    register_action('ffailure', nop, _failure_impl, expected_input='stream')
+    register_action('bad', nop, lambda _1, _2: [], output='stream')
+
+
+class RunTaskUnactionsWithNoActionsTests(TestCaseWithoutLogs):
+    def setUp(self):
+        super().setUp()
+        _register_actions()
+
+    def tearDown(self):
+        super().tearDown()
+        _clean_actions()
+
+    def test_run_unactions_should_work(self):
+        run_task_unactions('test', [])
+
+
+class RunTaskUnactionsWithOneActionTests(TestCaseWithoutLogs):
+    def setUp(self):
+        super().setUp()
+        _register_actions()
+
+    def tearDown(self):
+        super().tearDown()
+        _clean_actions()
+
+    def test_run_unactions_should_work(self):
+        actions = [{'final': 1}]
+
+        run_task_unactions('test', actions)
+
+    def test_run_unactions_with_incompatible_action_should_fail(self):
+        actions = [{'initial': 1}]
+
+        with self.assertRaises(Exception):
+            run_task_unactions('test', actions)
+
+    def test_run_unactions_with_action_without_unaction_should_fail(self):
+        actions = [{'initial-with-no-unaction': 1}]
+
+        with self.assertRaises(Exception):
+            run_task_unactions('test', actions)
+
+    def test_run_unactions_with_action_failing_should_raise_the_exception(self):
+        actions = [{'ffailure': 1}]
+
+        with self.assertRaisesRegex(KeyError, r'f'):
+            run_task_unactions('test', actions)
+
+    def test_run_unactions_with_unexisting_action_should_fail(self):
+        actions = [{'nope': None}]
+
+        with self.assertRaises(KeyError):
+            run_task_unactions('test', actions)
+
+
+class RunTaskUnactionsWithMultipleActionsTests(TestCaseWithoutLogs):
+    _initial_stream_mock = None
+    _middle_stream_mock = None
+
+    def setUp(self):
+        super().setUp()
+        _register_actions(self)
+
+    def tearDown(self):
+        super().tearDown()
+        _clean_actions()
+
+    def test_run_unactions_should_work(self):
+        actions = [{'initial': 1}, {'final': 2}]
+
+        run_task_unactions('test', actions)
+
+    def test_run_unactions_should_dispose_streams(self):
+        actions = [{'initial': 1}, {'final': 2}]
+
+        run_task_unactions('test', actions)
+
+        self._initial_stream_mock.close.assert_called_once()
+
+    def test_run_unactions_with_action_failing_should_raise_the_exception(self):
+        actions = [{'initial': 1}, {'ffailure': 2}]
+
+        with self.assertRaises(KeyError):
+            run_task_unactions('test', actions)
+
+    def test_run_unactions_with_bad_action_should_fail(self):
+        actions = [{'bad': ':(', 'final': ':(('}]
+
+        with self.assertRaises(Exception):
+            run_task_unactions('test', actions)
+
+    def test_run_unactions_should_work_2(self):
+        actions = [{'initial': 1}, {'middle': 2}, {'final': 3}]
+
+        run_task_unactions('test', actions)
+
+    def test_run_unactions_should_wait_for_the_process(self):
+        actions = [{'initial': 1}, {'middle': 2}, {'final': 3}]
+
+        run_task_unactions('test', actions)
+
+        self._initial_stream_mock.close.assert_called_once()
+        self._middle_stream_mock.wait.assert_called_once()
+
+    def test_run_unactions_should_fail_if_process_fails(self):
+        actions = [{'initial': 1}, {'middle': 2}, {'final': 3}]
+        self._middle_stream_mock.wait.return_value = 1
+
+        with self.assertRaises(Exception):
+            run_task_unactions('test', actions)
+
+        self._middle_stream_mock.stderr.__iter__.assert_called()
+
+    def test_run_unactions_should_kill_process_if_action_raises(self):
+        actions = [{'ifailure': 1}, {'middle': 2}, {'final': 3}]
+
+        with self.assertRaises(Exception):
+            run_task_unactions('test', actions)
+
+        self._middle_stream_mock.send_signal.assert_called_once()


### PR DESCRIPTION
This PR implements the base code for the restore operations via the *unactions* (reversed actions - *add reverte sticker here*). Also adds a new compress algorithm called `zst` and a new parameter for `encrypt-gpg` to enable compression (which now it is disabled by default).

Unactions implemented and tested:

- [X] tar
- [X] command
  - [X] With `reverse` defined
  - [X] With no `reverse` defined
- [X] ssh
  - [X] With `reverse` defined
  - [X] With no `reverse` defined
- [X] docker
  - [X] With `reverse` defined
  - [X] With no `reverse` defined
- [X] compress-xz
- [X] compress-gzip
- [X] compress-bz2
- [X] compress-br
- [X] compress-zst
- [ ] postgres-database
- [ ] mysql-database
- [ ] influxdb
- [X] from-file
- [X] from-file-ssh
- [X] to-file
- [X] copy-file
- [X] clone-file
- [X] from-directory *(NOTE: string parameter cannot be used, it will fail otherwise)*
- [X] from-physical-docker-volume
- [X] to-directory
- [X] copy-directory
- [X] encrypt-gpg